### PR TITLE
Temp disable top and bot text

### DIFF
--- a/server/app/controllers/posts_controller.rb
+++ b/server/app/controllers/posts_controller.rb
@@ -18,6 +18,7 @@ class PostsController < ApplicationController
 	  	toptxt = params[:post][:top_text]
  		bottxt = params[:post][:bot_text]
 
+
  		if post_params[:image].present?
 
  		unless toptxt.blank? && bottxt.blank?
@@ -26,6 +27,7 @@ class PostsController < ApplicationController
 		  	width = uploaded_image.columns
 		  	height = uploaded_image.rows/3
 
+=begin
 		  	unless toptxt.blank?
 			  	top_img = Magick::Image.read("caption:#{toptxt}") {
 				 	self.fill = '#FFFFFF'
@@ -49,6 +51,7 @@ class PostsController < ApplicationController
 				}.first
 				uploaded_image = uploaded_image.composite(bot_img, Magick::SouthGravity, Magick::OverCompositeOp)
 		  	end
+=end
 
 			uploaded_image.format = "png"
 			uploaded_image.write("_editedimage_.png")

--- a/server/app/views/posts/new.html.erb
+++ b/server/app/views/posts/new.html.erb
@@ -16,7 +16,7 @@
             <%= f.text_area :description %>
         </div>
     </div>
-    
+<% if false %>
     <div class="form-group row">
         <%= f.label :top_text, :class => "col-sm-2 col-form-label" %>
         <div class="col-sm-10">
@@ -29,6 +29,7 @@
             <%= f.text_area :bot_text %>
         </div>
     </div>
+<% end %>
     <div class="form-group row">
         <div class="col-sm-10">
             <%= f.submit "Post my meme!", class: 'btn btn-primary' %>

--- a/server/app/views/posts/new.html.erb
+++ b/server/app/views/posts/new.html.erb
@@ -16,20 +16,20 @@
             <%= f.text_area :description %>
         </div>
     </div>
-<% if false %>
     <div class="form-group row">
         <%= f.label :top_text, :class => "col-sm-2 col-form-label" %>
         <div class="col-sm-10">
-            <%= f.text_area :top_text %>
+            <%= f.label "temporarily disabled" %>
+            <%#= f.text_area :top_text %>
         </div>
     </div>
     <div class="form-group row">
         <%= f.label :bot_text, :class => "col-sm-2 col-form-label" %>
         <div class="col-sm-10">
-            <%= f.text_area :bot_text %>
+            <%= f.label "temporarily disabled" %>
+            <%#= f.text_area :bot_text %>
         </div>
     </div>
-<% end %>
     <div class="form-group row">
         <div class="col-sm-10">
             <%= f.submit "Post my meme!", class: 'btn btn-primary' %>

--- a/server/spec/system/post_system_spec.rb
+++ b/server/spec/system/post_system_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe "User management", :type => :system do
 	attach_file('post_image', path)
 	
 	fill_in "post_description", :with => "just a post"
-	fill_in "post_top_text", :with => "just a post"
-	fill_in "post_bot_text", :with => "just a post"
+	#fill_in "post_top_text", :with => "just a post"
+	#fill_in "post_bot_text", :with => "just a post"
 
   end
 
@@ -63,8 +63,8 @@ RSpec.describe "User management", :type => :system do
 	click_link "Upload Meme Now"
 	
 	fill_in "post_description", :with => "just a post"
-	fill_in "post_top_text", :with => "just a post"
-	fill_in "post_bot_text", :with => "just a post"
+	#fill_in "post_top_text", :with => "just a post"
+	#fill_in "post_bot_text", :with => "just a post"
 
 
 	click_button "Post my meme!"
@@ -98,8 +98,8 @@ RSpec.describe "User management", :type => :system do
 	click_link "Upload Meme Now"
 
 	attach_file('post_image', path)	
-	fill_in "post_top_text", :with => "just a post"
-	fill_in "post_bot_text", :with => "just a post"
+	#fill_in "post_top_text", :with => "just a post"
+	#fill_in "post_bot_text", :with => "just a post"
 
 
 	click_button "Post my meme!"


### PR DESCRIPTION
Disabled top and bot text areas that users could fill.
Added temp disabled message.
Disabled portion of tests that involved bot and top text.
Disabled portion of post creation that would add top and bot text to image without breaking current configuration.
(actually ran rspec this time ;) )